### PR TITLE
feat(prompt): allow creating changelog entries without config file

### DIFF
--- a/.chachalog/w4XUmMTi.md
+++ b/.chachalog/w4XUmMTi.md
@@ -1,0 +1,5 @@
+---
+"@chachalog": minor
+---
+
+Allow `npx chachalog prompt` to work without a configuration file. When no config exists, users can now create changelog entries without specifying version bumps. The command will display a yellow warning and create entries in the `.chachalog/` directory with empty version information.

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -10,7 +10,7 @@ import doctor from "./commands/doctor.ts";
 import prepareNextRelease from "./commands/prepare-next-release.ts";
 import prompt from "./commands/prompt.ts";
 import publishRelease from "./commands/publish-release.ts";
-import { CommandWithConfig, CommandWithLocalConfig, loadConfig } from "./config.ts";
+import { CommandWithConfig, CommandWithLocalConfig, CommandWithOptionalLocalConfig, loadConfig } from "./config.ts";
 
 await Cli.from(
   [
@@ -79,13 +79,13 @@ await Cli.from(
         }
       }
     },
-    class extends CommandWithLocalConfig {
+    class extends CommandWithOptionalLocalConfig {
       static paths = [["prompt"]];
       static usage = Command.Usage({
         category: "Helpers",
         description: "Interactively create a new changelog entry",
       });
-      async executeWithLocalConfig() {
+      async executeWithOptionalLocalConfig() {
         await prompt(this);
       }
     },

--- a/src/commands/prompt.test.ts
+++ b/src/commands/prompt.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { rmSync, existsSync, mkdirSync } from "node:fs";
+import test, { afterEach, beforeEach, suite } from "node:test";
+import { createOptionalLocalContext } from "../config.test.ts";
+
+const cwd = "_fixtures-prompt-test";
+
+suite("prompt command - configuration handling", () => {
+  beforeEach(() => {
+    if (!existsSync(cwd)) {
+      mkdirSync(cwd, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  suite("context creation for optional config", () => {
+    test("createOptionalLocalContext without config creates null config", async () => {
+      const context = await createOptionalLocalContext(null, { dir: cwd });
+      assert.equal(context.config, null);
+    });
+
+    test("createOptionalLocalContext with config creates valid config", async () => {
+      const foo = { name: "foo", path: "/path/to/foo", version: "1.0.0" };
+      const context = await createOptionalLocalContext(
+        {
+          managers: { packages: [foo], setVersion: () => true },
+        },
+        { dir: cwd },
+      );
+      assert.notEqual(context.config, null);
+      assert.ok(context.config);
+      if (context.config) {
+        assert.equal(context.config.packages[0].name, "foo");
+      }
+    });
+
+    test("createOptionalLocalContext with multiple packages", async () => {
+      const foo = { name: "foo", path: "/path/to/foo", version: "1.0.0" };
+      const bar = { name: "bar", path: "/path/to/bar", version: "2.0.0" };
+      const context = await createOptionalLocalContext(
+        {
+          managers: { packages: [foo, bar], setVersion: () => true },
+        },
+        { dir: cwd },
+      );
+      assert.notEqual(context.config, null);
+      assert.ok(context.config);
+      if (context.config) {
+        assert.equal(context.config.packages.length, 2);
+        assert.equal(context.config.packages[0].name, "foo");
+        assert.equal(context.config.packages[1].name, "bar");
+      }
+    });
+
+    test("dir property is set correctly on optional context", async () => {
+      const context = await createOptionalLocalContext(null, { dir: cwd });
+      assert.equal(context.dir, cwd);
+    });
+
+    test("allowedBumps defaults correctly in optional context with config", async () => {
+      const foo = { name: "foo", path: "/path/to/foo", version: "1.0.0" };
+      const context = await createOptionalLocalContext(
+        {
+          managers: { packages: [foo], setVersion: () => true },
+        },
+        { dir: cwd },
+      );
+      assert.notEqual(context.config, null);
+      assert.ok(context.config);
+      if (context.config) {
+        // should have all default bump types
+        assert.ok(context.config.allowedBumps.includes("patch"));
+        assert.ok(context.config.allowedBumps.includes("minor"));
+        assert.ok(context.config.allowedBumps.includes("major"));
+      }
+    });
+
+    test("custom allowedBumps are used in optional context", async () => {
+      const foo = { name: "foo", path: "/path/to/foo", version: "1.0.0" };
+      const context = await createOptionalLocalContext(
+        {
+          managers: { packages: [foo], setVersion: () => true },
+          allowedBumps: ["prerelease"],
+        },
+        { dir: cwd },
+      );
+      assert.notEqual(context.config, null);
+      assert.ok(context.config);
+      if (context.config) {
+        assert.deepEqual(context.config.allowedBumps, ["prerelease"]);
+      }
+    });
+  });
+
+  suite("optional config behavior", () => {
+    test("prompt command can be created with null config (no config file)", async () => {
+      // Test that CommandWithOptionalLocalConfig accepts null config
+      const context = await createOptionalLocalContext(null, { dir: cwd });
+      assert.equal(context.config, null);
+      // context.dir should still be accessible
+      assert.equal(context.dir, cwd);
+    });
+
+    test("prompt command can be created with valid config (config file exists)", async () => {
+      // Test that CommandWithOptionalLocalConfig properly resolves config
+      const foo = { name: "foo", path: "/path/to/foo", version: "1.0.0" };
+      const context = await createOptionalLocalContext(
+        {
+          managers: { packages: [foo], setVersion: () => true },
+        },
+        { dir: cwd },
+      );
+      assert.notEqual(context.config, null);
+      assert.ok(context.config);
+    });
+  });
+});
+

--- a/src/commands/prompt.ts
+++ b/src/commands/prompt.ts
@@ -2,41 +2,47 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import * as p from "@clack/prompts";
 import * as yaml from "yaml";
-import type { CommandWithLocalConfig } from "../config.ts";
+import { styleText } from "node:util";
+import type { CommandWithOptionalLocalConfig } from "../config.ts";
 import type { ReleaseTypes } from "../index.ts";
 
 /** Interactively create a new changelog entry */
-export default async function prompt({ config, dir }: CommandWithLocalConfig) {
+export default async function prompt({ config, dir }: CommandWithOptionalLocalConfig) {
   const filename = path.join(
     dir,
     `${Buffer.from(crypto.getRandomValues(new Uint8Array(6))).toString("base64url")}.md`,
   );
   const bumps: Record<string, ReleaseTypes> = {};
 
-  p.intro("🦜 Pick version bumps");
+  if (!config) {
+    p.intro("🦜 Create changelog entry (no config file)");
+    console.warn(styleText("yellow", "No configuration file found, creating an empty entry."));
+  } else {
+    p.intro("🦜 Pick version bumps");
 
-  for (const pkg of config.packages) {
-    const bump = await p.select({
-      message: `Bump for ${pkg.name}`,
-      options: [
-        { value: null, label: "Skip", hint: "I don't want to bump" },
-        ...config.allowedBumps.map((value) => ({ value })),
-      ],
-    });
+    for (const pkg of config.packages) {
+      const bump = await p.select({
+        message: `Bump for ${pkg.name}`,
+        options: [
+          { value: null, label: "Skip", hint: "I don't want to bump" },
+          ...config.allowedBumps.map((value) => ({ value })),
+        ],
+      });
 
-    if (p.isCancel(bump)) {
-      p.cancel("Bump cancelled, come back soon!");
-      return 0;
+      if (p.isCancel(bump)) {
+        p.cancel("Bump cancelled, come back soon!");
+        return 0;
+      }
+
+      if (bump === null) continue;
+
+      bumps[pkg.name] = bump;
     }
 
-    if (bump === null) continue;
-
-    bumps[pkg.name] = bump;
-  }
-
-  if (Object.keys(bumps).length === 0) {
-    p.outro("Nothing to bump, exiting...");
-    return 0;
+    if (Object.keys(bumps).length === 0) {
+      p.outro("Nothing to bump, exiting...");
+      return 0;
+    }
   }
 
   const entry = await p.text({

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2,6 +2,7 @@ import { type Mock, mock } from "node:test";
 import {
   CommandWithConfig,
   CommandWithLocalConfig,
+  CommandWithOptionalLocalConfig,
   resolveConfig,
   resolveLocalConfig,
 } from "./config.ts";
@@ -53,5 +54,19 @@ export const createLocalContext = async (
     config = resolved;
     dir = dir;
     async executeWithLocalConfig() {}
+  })();
+};
+
+export const createOptionalLocalContext = async (
+  config: Omit<UserConfig, "platform"> | null,
+  { dir = "custom" }: { dir?: string } = {},
+): Promise<CommandWithOptionalLocalConfig> => {
+  const resolved = config
+    ? await resolveLocalConfig({ ...config, platform: createMockPlatform() })
+    : null;
+  return new (class extends CommandWithOptionalLocalConfig {
+    config = resolved;
+    dir = dir;
+    async executeWithOptionalLocalConfig() {}
   })();
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -118,8 +118,8 @@ const latestVersion = fetch("https://registry.npmjs.org/chachalog/latest", {
   .then((data: { version: string }) => (semver.gt(data.version, pkg.version) ? data.version : null))
   .catch(() => null);
 
-/** Finds a config file in `dir`, returns its absolute path or throws. */
-async function findConfigFile(dir: string) {
+/** Finds a config file in `dir`, returns its absolute path or null if not found (when optional=true), or throws. */
+async function findConfigFile(dir: string, optional = false) {
   const extensions = ["js", "mjs", "ts", "mts"];
   for (const file of extensions) {
     try {
@@ -128,6 +128,7 @@ async function findConfigFile(dir: string) {
       return config;
     } catch {}
   }
+  if (optional) return null;
   throw new UsageError(`No config file found in ${dir}/config.{${extensions.join(",")}}`);
 }
 
@@ -136,9 +137,14 @@ async function findConfigFile(dir: string) {
  *
  * We copy `dist` and `package.json` into a temporary `node_modules` folder. This allows users to
  * import `chachalog` in their config without having to install it.
+ *
+ * If `optional` is true, returns null if no config file is found instead of throwing.
  */
-export async function loadConfig(dir: string) {
-  const configFile = await findConfigFile(dir);
+export function loadConfig(dir: string, optional: true): Promise<(() => UserConfig | Promise<UserConfig>) | null>;
+export function loadConfig(dir: string, optional?: false): Promise<() => UserConfig | Promise<UserConfig>>;
+export async function loadConfig(dir: string, optional = false): Promise<(() => UserConfig | Promise<UserConfig>) | null> {
+  const configFile = await findConfigFile(dir, optional);
+  if (!configFile) return null;
   try {
     await fs.cp(
       new URL(".", import.meta.resolve("chachalog")),
@@ -169,6 +175,25 @@ export abstract class CommandWithLocalConfig extends Command {
   }
 
   abstract executeWithLocalConfig(): Promise<number | void>;
+}
+
+/** Runs a command with an optional resolved local config (not platform). Returns null if no config file exists. */
+export abstract class CommandWithOptionalLocalConfig extends Command {
+  dir = Option.String("-d,--dir", ".chachalog", { description: "Chachalog directory" });
+  config!: Awaited<ReturnType<typeof resolveLocalConfig>> | null;
+
+  async execute() {
+    const configFn = await loadConfig(this.dir, true);
+    if (configFn) {
+      const raw = await configFn();
+      this.config = await resolveLocalConfig(raw);
+    } else {
+      this.config = null;
+    }
+    return this.executeWithOptionalLocalConfig();
+  }
+
+  abstract executeWithOptionalLocalConfig(): Promise<number | void>;
 }
 
 /** Runs a command with a resolved config. */


### PR DESCRIPTION
## 💡 What's the change?

This PR enables users to run `npx chachalog prompt` even when no Chachalog configuration file (`.chachalog/config.*`) exists. Previously, the command would fail with an error. Now it gracefully handles the missing config and allows users to create changelog entries without specifying version bumps.

## 🎯 Why?

Users might want to:
- Create changelog entries during initial project setup (before config is ready)
- Use Chachalog incrementally without full configuration
- Generate entries that don't require version-specific bumps


## 📝 How it works

### Output Example
```
% npx chachalog prompt                                                                  
┌  🦜 Create changelog entry (no config file)
No configuration file found. Creating entry without version bumps.
│
◇  Changelog entry
│  Fixed critical bug in authentication
└  Entry created at .chachalog/nk2ZB66V.md
```
